### PR TITLE
#2 break out environment loading for non-fw1 apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,28 +3,137 @@
 
 An FW/1 subsystem for loading external configurations into an application accessible bean object.
 
-## How to Use
+## Requirements
 
-1. Include `fw1dotenv` in your FW/1 application's designated `subsystems` directory. If you do not already have a `subsystems` directory, create the directory wherever the rest of your core framework structure lives. You may refer to the [FW/1 Documentation](http://framework-one.github.io/documentation/developing-applications.html#basic-application-structure) for a rundown of a typical structure.
-1. Configure your FW/1 settings to include the location of your settings file and the subsystem's load listener for integrating the settings as a bean.
-    ```cfc
-	variables.framework = {
-	  // ... other framework settings
-	  dotenv: {
-	    fileName: "/path/to/settings/file/.env"
-	  }
-	  subsystems: {
-	    fw1dotenv: {
-	      diLocations: "model",
-	      diConfig: {
-	        omitDirectoryAliases: true,
-	        loadListener: "DotenvListener"
-	      }
-	    }
-	  }
-	}
-    ```
+* Lucee 5.x+ or Adobe ColdFusion 2016+
+* FW/1 4.x+
 
-    > Note: The settings file may be any type of readable extension (.env, txt, json, properties etc.) and contain variables stored in either JSON ({ "key": "value" }) or Properties (key=value) formats.
+> Note: FW/1 Dotenv may also be used outside of FW/1 applications but with some obvious limitations. See the `Usage` section for more info.
 
-1. To access the newly wired settings in your application, you can inject the `SystemSettings` bean into your other DI/1 aware beans via `property SystemSettings;` or manually call the bean from the default bean factory with `getBeanFactory().getBean("SystemSettings");`.
+## Installation
+
+### CommandBox
+
+Installation via ForgeBox/CommandBox coming soon...
+
+### Manual
+
+#### FW/1
+
+Include `fw1dotenv` in your FW/1 application's designated `subsystems` directory. If you do not already have a `subsystems` directory, create the directory wherever the rest of your core framework structure lives. You may refer to the [FW/1 Documentation](http://framework-one.github.io/documentation/developing-applications.html#basic-application-structure) for a rundown of a typical structure.
+
+## Configuration
+
+### Default Setup
+
+Configure your FW/1 settings variable to include the location of your settings file and the subsystem's load listener for integrating the settings as a bean.
+
+> Note: The settings file may be any type of readable extension (i.e: .env, .txt, .json, .properties etc.) and contain variables stored in either JSON ({ "key": "value" }) or Properties (key=value) formats.
+
+```cfc
+variables.framework = {
+    // ... other framework settings
+    dotenv: {
+        fileName: "/path/to/settings/file/.env"
+    }
+    subsystems: {
+        fw1dotenv: {
+            diLocations: "model",
+            diConfig: {
+                omitDirectoryAliases: true,
+                loadListener: "DotenvListener"
+            }
+        }
+    }
+}
+```
+
+### Creating a Bean Alias
+
+To assign an alternative naming convention to the settings bean, you can include a `beanAlias` key with a name value in the `dotenv` struct.
+
+```cfc
+variables.framework = {
+    // ... other framework settings
+    dotenv: {
+        beanAlias: "MyCustomBeanName",
+        fileName: "/path/to/settings/file/.env"
+    }
+    // ... other framework settings
+}
+```
+
+## Usage
+
+### Default Convention
+
+To access the newly wired settings in your application, you can call the bean from the `fw1dotenv` subsystem bean factory using `getBeanFactory( "fw1dotenv" ).getBean( "SystemSettings" );`.
+
+### Adding to the Parent Bean Factory
+
+If you would like to make the settings bean available to your main/parent bean factory, you can declare it as a new bean in `setupApplication()` or the parent bean factory's `load listener`.
+
+#### setupApplication()
+
+```cfc
+setupApplication() {
+    // ... some other code
+    getBeanFactory().declare( "SystemSettings" ).asValue( getBeanFactory( "fw1dotenv" ).getBean( "SystemSettings" ) );
+}
+```
+
+#### Load Listener via variables.framework
+
+```cfc
+variables.framework = {
+    // ... other framework settings
+    diEngine: "di1",
+    diLocations: [ "/path/to/beans" ],
+    diConfig: {
+        loadListener: function(di1) {
+            di1.declare( "SystemSettings" ).asValue( getBeanFactory( "fw1dotenv" ).getBean( "SystemSettings" ) );
+        }
+    }
+    // ... other framework settings
+}
+```
+
+#### Load Listener via CFC
+
+```cfc
+// Application.cfc (or your alternative config location)
+variables.framework = {
+    // ... other framework settings
+    diEngine: "di1",
+    diLocations: [ "/path/to/beans" ],
+    diConfig: { loadListener: "MyLoadListener" }
+    // ... other framework settings
+}
+
+// MyLoadListener.cfc
+component {
+    public function onLoad( di1 ) {
+        var settings = arguments.di1.getBean( "fw" ).getBeanFactory( "fw1dotenv" ).getBean( "SystemSettings" );
+        arguments.di1.declare( "SystemSettings" ).asValue( settings );
+    }
+}
+```
+
+### Non-FW/1 Apps
+
+FW/1 Dotenv can be used without FW/1 by instantiating `DotenvService.cfc` and calling `loadSettings()`.
+
+```cfc
+dotenvService = new fw1dotenv.model.services.DotenvService();
+settings = dotenvService.loadSettings( filePath = "path/to/settings/file/.env" );
+```
+
+## Development
+
+### Running Tests With CommandBox & TestBox
+
+From the project root, start CommandBox in your preferred terminal and point to the `/test-harness` directory (`cd test-harness`). Include the test dependencies (FW/1 & TestBox) by running `install`. Start the server by executing `server start`. The server instance will be located at `http://127.0.0.1:8520`.
+
+> Note: By default, the test harness server will use Lucee 5. To use a specific engine/version, either update the `server.json` or run `server start cfengine=[engine]@[version]`.
+
+Once the server has started, you can run `testbox run` in the terminal to execute the tests. To view the test results in the browser, you can navigate to `http://127.0.0.1:8520/tests/runner.cfm`.

--- a/box.json
+++ b/box.json
@@ -1,7 +1,7 @@
 {
     "name":"FW/1 Dotenv",
     "slug":"fw1dotenv",
-    "version":"1.0.0",
+    "version":"1.2.0",
     "author":"@tonyjunkes",
     "location":"tonyjunkes/fw1dotenv#develop",
     "createPackageDirectory":true,

--- a/model/DotenvListener.cfc
+++ b/model/DotenvListener.cfc
@@ -2,39 +2,20 @@ component
     accessors=true
     output=false
 {
-    property fw;
+    property DotenvService;
 
     public function onLoad( di1 ) {
-        // Get configuration file from framework subsystem settings
-        var fw1Config = variables.fw.getConfig();
-        var envFilePath = expandPath( fw1Config?.dotenv?.fileName );
-        if ( fileExists( envFilePath ) ) {
-            var envFile = fileRead( envFilePath );
-            // If JSON, deserialize natively and include as bean
-            if ( isJSON( envFile ) ) {
-                // Load the bean into the parent bean factory
-                variables.fw.getBeanFactory().declare( "SystemSettings" ).asValue( deserializeJSON( envFile ) );
-            } else {
-                // Otherwise load as properties format and include as bean
-                var FileInputStream = createObject( "java", "java.io.FileInputStream" );
-                var Properties = createObject( "java", "java.util.Properties" ).init();
-                Properties.load( FileInputStream.init( envFilePath ) );
-                // To avoid case sensitivity issues when accessing key/value pairs
-                var envVars = {};
-                Properties.each(function( prop ) {
-                    envVars[ arguments.prop ] = Properties[ arguments.prop ];
-                });
-                // Load the bean into the parent bean factory
-                variables.fw.getBeanFactory().declare( "SystemSettings" ).asValue( envVars );
-            }
-            // Setup alias if config exists in framework settings
-            if ( len( fw1Config?.dotenv?.beanAlias ) ) {
-                variables.fw.getBeanFactory().declare( fw1Config.dotenv.beanAlias ).aliasFor( "SystemSettings" );
-            }
-        } else {
-            // Print to console if no file can be found
-            var System = createObject( "java", "java.lang.System" );
-            System.out.println( "[fw1dotenv]: Cannot find environment file." );
+        // Get configuration file from framework settings
+        var fw1Config = arguments.di1.getBean( "fw" ).getConfig();
+        // Load env settings
+        var envPath = expandPath( fw1Config?.dotenv?.fileName );
+        var settings = variables.DotenvService.loadSettings( filePath = envPath );
+        // Load the bean into the parent bean factory
+        arguments.di1.declare( "SystemSettings" ).asValue( settings );
+        // Setup alias if config exists in framework settings
+        var beanAlias = fw1Config?.dotenv?.beanAlias ?: "";
+        if ( beanAlias.len() ) {
+            arguments.di1.declare( beanAlias ).aliasFor( "SystemSettings" );
         }
     }
 }

--- a/model/services/DotenvService.cfc
+++ b/model/services/DotenvService.cfc
@@ -1,0 +1,31 @@
+component
+    output=false
+{
+    public DotenvService function init() {
+        return this;
+    }
+
+    public function loadSettings( required string filePath ) {
+        var envVars = {};
+        if ( fileExists( arguments.filePath ) ) {
+            var envFile = fileRead( arguments.filePath );
+            // If JSON, deserialize natively
+            if ( isJSON( envFile ) ) {
+                envVars = deserializeJSON( envFile );
+            } else {
+                // Otherwise load as properties format and convert to CFML struct
+                var FileInputStream = createObject( "java", "java.io.FileInputStream" );
+                var Properties = createObject( "java", "java.util.Properties" ).init();
+                Properties.load( FileInputStream.init( arguments.filePath ) );
+                Properties.each(function( prop ) {
+                    envVars[ arguments.prop ] = Properties[ arguments.prop ];
+                });
+            }
+        } else {
+            // Throw error if no file can be found
+            throw( "[fw1dotenv]: Could not find environment file." );
+        }
+
+        return envVars;
+    }
+}

--- a/test-harness/tests/Application.cfc
+++ b/test-harness/tests/Application.cfc
@@ -6,6 +6,8 @@ component {
         "/resources": variables.testsPath & "./resources",
         "/testbox": variables.testsPath & "../testbox",
         "/framework": variables.testsPath & "../framework",
-        "/model": variables.testsPath & "../../model"
+        "/model": variables.testsPath & "../../model",
+        // This is to fake the subsystem location
+        "/tests/subsystems/fw1dotenv/model": variables.testsPath & "../../model"
     };
 }

--- a/test-harness/tests/specs/DotenvListenerSpec.cfc
+++ b/test-harness/tests/specs/DotenvListenerSpec.cfc
@@ -1,27 +1,39 @@
 component extends="testbox.system.BaseSpec" {
 
+    function __config() {
+        return variables.framework;
+    }
+
     function run() {
-        describe( "Tests FW/1 Dotenv", function() {
+        describe( "FW/1 Dotenv load listener", function() {
             beforeEach(function( currentSpec ) {
                 // Reset the framework instance before each spec is run
                 request.delete( "_fw1" );
                 variables.fw = new framework.one();
                 variables.fw.__config = __config;
                 variables.fw.__config().append({
-                    diLocations: "/model",
-                    diConfig: {
-                        omitDirectoryAliases: true,
-                        loadListener: "DotenvListener"
+                    subsystems: {
+                        fw1dotenv: {
+                            diLocations: "/model",
+                            diConfig: {
+                                omitDirectoryAliases: true,
+                                loadListener: "DotenvListener"
+                            }
+                        }
                     }
                 });
             });
 
-            it( "Tests load listener is discovered", function() {
+            it( "Tests exception when file not found", function() {
+                variables.fw.__config().append({
+                    dotenv: {
+                        fileName: "/resources/.notafile.env"
+                    }
+                });
                 variables.fw.onApplicationStart();
 
-                // Load listener is loaded
-                var moduleExists = variables.fw.getBeanFactory().containsBean( "DotenvListener" );
-                expect( moduleExists ).toBeTrue();
+                expect( function() { variables.fw.getBeanFactory().getBean( "SystemSettings" ); } )
+                        .toThrow( message = "[fw1dotenv]: Could not find environment file." );
             });
 
             it( "Tests SystemSettings bean is created from a .env properties file", function() {
@@ -32,14 +44,13 @@ component extends="testbox.system.BaseSpec" {
                 });
                 variables.fw.onApplicationStart();
 
-                // Bean is created
-                var beanExists = variables.fw.getBeanFactory().containsBean( "SystemSettings" );
+                var beanExists = variables.fw.getBeanFactory( "fw1dotenv" ).containsBean( "SystemSettings" );
                 expect( beanExists ).toBeTrue();
 
-                var beanType = variables.fw.getBeanFactory().getBean( "SystemSettings" );
+                var beanType = variables.fw.getBeanFactory( "fw1dotenv" ).getBean( "SystemSettings" );
                 expect( beanType ).toBeTypeOf( "struct" );
 
-                var beanVal = variables.fw.getBeanFactory().getBean( "SystemSettings" ).testkey;
+                var beanVal = variables.fw.getBeanFactory( "fw1dotenv" ).getBean( "SystemSettings" ).testkey;
                 expect( beanVal ).toBe( "test_env_value" );
             });
 
@@ -51,13 +62,13 @@ component extends="testbox.system.BaseSpec" {
                 });
                 variables.fw.onApplicationStart();
 
-                var beanExists = variables.fw.getBeanFactory().containsBean( "SystemSettings" );
+                var beanExists = variables.fw.getBeanFactory( "fw1dotenv" ).containsBean( "SystemSettings" );
                 expect( beanExists ).toBeTrue();
 
-                var beanType = variables.fw.getBeanFactory().getBean( "SystemSettings" );
+                var beanType = variables.fw.getBeanFactory( "fw1dotenv" ).getBean( "SystemSettings" );
                 expect( beanType ).toBeTypeOf( "struct" );
 
-                var beanVal = variables.fw.getBeanFactory().getBean( "SystemSettings" ).testkey;
+                var beanVal = variables.fw.getBeanFactory( "fw1dotenv" ).getBean( "SystemSettings" ).testkey;
                 expect( beanVal ).toBe( "test_properties_value" );
             });
 
@@ -69,13 +80,13 @@ component extends="testbox.system.BaseSpec" {
                 });
                 variables.fw.onApplicationStart();
 
-                var beanExists = variables.fw.getBeanFactory().containsBean( "SystemSettings" );
+                var beanExists = variables.fw.getBeanFactory( "fw1dotenv" ).containsBean( "SystemSettings" );
                 expect( beanExists ).toBeTrue();
 
-                var beanType = variables.fw.getBeanFactory().getBean( "SystemSettings" );
+                var beanType = variables.fw.getBeanFactory( "fw1dotenv" ).getBean( "SystemSettings" );
                 expect( beanType ).toBeTypeOf( "struct" );
 
-                var beanVal = variables.fw.getBeanFactory().getBean( "SystemSettings" ).testkey;
+                var beanVal = variables.fw.getBeanFactory( "fw1dotenv" ).getBean( "SystemSettings" ).testkey;
                 expect( beanVal ).toBe( "test_json_value" );
             });
 
@@ -88,20 +99,16 @@ component extends="testbox.system.BaseSpec" {
                 });
                 variables.fw.onApplicationStart();
 
-                var beanExists = variables.fw.getBeanFactory().containsBean( "CustomNameSettings" );
+                var beanExists = variables.fw.getBeanFactory( "fw1dotenv" ).containsBean( "CustomNameSettings" );
                 expect( beanExists ).toBeTrue();
 
-                var beanType = variables.fw.getBeanFactory().getBean( "CustomNameSettings" );
+                var beanType = variables.fw.getBeanFactory( "fw1dotenv" ).getBean( "CustomNameSettings" );
                 expect( beanType ).toBeTypeOf( "struct" );
 
-                var beanVal = variables.fw.getBeanFactory().getBean( "CustomNameSettings" ).testkey;
+                var beanVal = variables.fw.getBeanFactory( "fw1dotenv" ).getBean( "CustomNameSettings" ).testkey;
                 expect( beanVal ).toBe( "test_env_value" );
             });
         });
-    }
-
-    function __config() {
-        return variables.framework;
     }
 
 }

--- a/test-harness/tests/specs/DotenvServiceSpec.cfc
+++ b/test-harness/tests/specs/DotenvServiceSpec.cfc
@@ -1,0 +1,44 @@
+component extends="testbox.system.BaseSpec" {
+
+    function beforeAll() {
+        variables.DotenvService = createMock( "model.services.DotenvService" );
+    };
+
+    function run() {
+        describe( "FW/1 Dotenv service", function() {
+            it( "Tests exception when file not found", function() {
+                var envFile = expandPath( "/resources/.notafile.env" );
+                expect( function() { variables.DotenvService.loadSettings( envFile ); } )
+                        .toThrow( message = "[fw1dotenv]: Could not find environment file." );
+            });
+
+            it( "Tests settings struct is created from a .env properties file", function() {
+                var envFile = expandPath( "/resources/.env" );
+                var settings = variables.DotenvService.loadSettings( filePath = envFile );
+                // Struct returned
+                expect( settings ).toBeTypeOf( "struct" );
+                // Verify struct data
+                expect( settings.testkey ).toBe( "test_env_value" );
+            });
+
+            it( "Tests settings struct is created from a standard properties file", function() {
+                var envFile = expandPath( "/resources/settings.properties" );
+                var settings = variables.DotenvService.loadSettings( filePath = envFile );
+                // Struct returned
+                expect( settings ).toBeTypeOf( "struct" );
+                // Verify struct data
+                expect( settings.testkey ).toBe( "test_properties_value" );
+            });
+
+            it( "Tests settings struct is created from a json file", function() {
+                var envFile = expandPath( "/resources/settings.json" );
+                var settings = variables.DotenvService.loadSettings( filePath = envFile );
+                // Struct returned
+                expect( settings ).toBeTypeOf( "struct" );
+                // Verify struct data
+                expect( settings.testkey ).toBe( "test_json_value" );
+            });
+        });
+    }
+
+}


### PR DESCRIPTION
Environment loading has been moved to a service CFC that can be instantiated by apps not using FW/1. Also updated the docs to reflect all current capabilities of the library.